### PR TITLE
Use string primitive in typings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function createActionNames(rpcId) {
   }, {});
 }
 
-export function createRPCActions(rpcId: String) {
+export function createRPCActions(rpcId: string) {
   const actionNames = createActionNames(rpcId);
   return types.reduce((obj, type) => {
     obj[type] = (payload: any) => {
@@ -40,7 +40,7 @@ function getNormalizedReducers(reducers) {
 }
 
 export function createRPCReducer(
-  rpcId: String,
+  rpcId: string,
   reducers: any,
   startValue: any = {}
 ) {
@@ -61,7 +61,7 @@ export function createRPCReducer(
   };
 }
 
-export function createRPCReactors(rpcId: String, reducers: any) {
+export function createRPCReactors(rpcId: string, reducers: any) {
   const actionNames = createActionNames(rpcId);
   reducers = getNormalizedReducers(reducers);
   const reactors = types.reduce((obj, type) => {


### PR DESCRIPTION
The flow typings for this package use the String class for strings,
which means it typechecks for string objects created with the
`new String(...)` syntax and not string literals. This is unidiomatic
JS and we probably meant to use the string primitive.

Fixes #67 