### PR TITLE
Expose .originalError property for error objects that don't match the {message, code, meta} interface

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -96,6 +96,7 @@ test('createRPCHandler failure', t => {
       },
       failure: e => {
         t.deepLooseEqual(e, {
+          originalError: error,
           message: error.message,
           code: undefined,
           meta: undefined,

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,9 @@ export function createRPCHandler({
       .catch(e => {
         // error objects stringify to {} by default, so we should pluck the properties we care about
         const {message, code, meta} = e;
-        store.dispatch(actions.failure({message, code, meta}));
+        store.dispatch(
+          actions.failure({originalError: e, message, code, meta})
+        );
         return e;
       });
   };


### PR DESCRIPTION
Different systems can output "error" objects with arbitrary structures and may or may not have a `.message` field. This makes it difficult to normalize then into the `{message, code, meta}` interface. To allow downstream error consumers to be able to work with these types of error objects, a new property containing the original error is provided.