### PR TITLE
Fix flow types for createRPCReducer interface

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
 <PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/src/fixtures/
 
 [include]
 

--- a/flow-typed/redux-reactors_v1.x.x.js
+++ b/flow-typed/redux-reactors_v1.x.x.js
@@ -8,7 +8,7 @@ declare module 'redux-reactors' {
   declare type Reactor<TType, TPayload> = (payload: TPayload) => ({
     type: TType,
     payload: TPayload,
-    __REACTOR__: boolean
+    __REACTOR__: any
   });
-  declare function createReactor<TType>(type: TType, reducer: Reducer<*, *>): Reactor<TType, *>;
+  declare function createReactor<TType, S>(type: TType, reducer: Reducer<TType, S>): Reactor<TType, *>;
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.10.0",
+    "execa": "^0.10.0",
     "flow-bin": "^0.76.0",
     "nyc": "^11.7.3",
     "prettier": "^1.12.1",

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -7,12 +7,27 @@
  */
 
 import test from 'tape-cup';
+import execa from 'execa';
 import {
   createRPCHandler,
   createRPCReactors,
   createRPCActions,
   createRPCReducer,
 } from '../index';
+
+test('Flow tests', async t => {
+  const failurePath = 'src/fixtures/failure';
+  const successPath = 'src/fixtures/success';
+  try {
+    await execa.shell(`flow check ${failurePath}`);
+    t.fail('Should fail flow check');
+  } catch (e) {
+    const {stdout} = e;
+    t.ok(stdout.includes('Found 5 errors'));
+  }
+  await execa.shell(`flow check ${successPath}`);
+  t.end();
+});
 
 test('api', t => {
   t.equal(typeof createRPCHandler, 'function', 'exposes a getHandler function');
@@ -257,24 +272,42 @@ test('createRPCReducer', t => {
     }),
     'test-failure'
   );
-  t.equal(reducer('abcd', {type: 'abcd'}), 'abcd');
+  t.equal(reducer('abcd', {type: 'abcd', payload: {}}), 'abcd');
   t.end();
 });
 
 test('createRPCReducer default reducers', t => {
   const reducer = createRPCReducer('getCount', {});
   const initialState = {a: 'b'};
-  t.equal(reducer(initialState, {type: 'GET_COUNT_START'}), initialState);
-  t.equal(reducer(initialState, {type: 'GET_COUNT_SUCCESS'}), initialState);
-  t.equal(reducer(initialState, {type: 'GET_COUNT_FAILURE'}), initialState);
+  t.equal(
+    reducer(initialState, {type: 'GET_COUNT_START', payload: {}}),
+    initialState
+  );
+  t.equal(
+    reducer(initialState, {type: 'GET_COUNT_SUCCESS', payload: {}}),
+    initialState
+  );
+  t.equal(
+    reducer(initialState, {type: 'GET_COUNT_FAILURE', payload: {}}),
+    initialState
+  );
   t.end();
 });
 
 test('createRPCReducer custom default state', t => {
   const initialState = 123;
   const reducer = createRPCReducer('getCount', {}, initialState);
-  t.equal(reducer(initialState, {type: 'GET_COUNT_START'}), initialState);
-  t.equal(reducer(initialState, {type: 'GET_COUNT_SUCCESS'}), initialState);
-  t.equal(reducer(initialState, {type: 'GET_COUNT_FAILURE'}), initialState);
+  t.equal(
+    reducer(initialState, {type: 'GET_COUNT_START', payload: {}}),
+    initialState
+  );
+  t.equal(
+    reducer(initialState, {type: 'GET_COUNT_SUCCESS', payload: {}}),
+    initialState
+  );
+  t.equal(
+    reducer(initialState, {type: 'GET_COUNT_FAILURE', payload: {}}),
+    initialState
+  );
   t.end();
 });

--- a/src/fixtures/failure/.flowconfig
+++ b/src/fixtures/failure/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+
+[include]
+../../index.js
+
+[libs]
+../../../flow-typed
+
+[lints]
+
+[options]
+
+[strict]

--- a/src/fixtures/failure/flow-failure.js
+++ b/src/fixtures/failure/flow-failure.js
@@ -1,0 +1,59 @@
+// @flow
+import type {Reducer} from 'redux';
+import {createRPCReducer} from '../../index.js';
+
+type UserDataType = {
+  firstName: string,
+  lastName: string,
+};
+type ErrorType = {
+  message: string,
+};
+
+export type UserStateType = {|
+  loading: boolean,
+  data: ?UserDataType,
+  error: ?ErrorType,
+|};
+
+export type UserActionType = {|
+  type: string,
+  payload: {
+    data: ?UserDataType,
+    error: ?ErrorType,
+  },
+|};
+
+const UserReducer: Reducer<UserStateType, UserActionType> = createRPCReducer(
+  'getUser',
+  {
+    start: () => {
+      return {
+        loading: true,
+      };
+    },
+    success: (state, action) => {
+      return {
+        ...state,
+        loading: 'test',
+        data: action.payload.data,
+      };
+    },
+    failure: (state, action) => {
+      return {
+        loading: false,
+        data: null,
+        error: action.payload.error,
+        extra: 'test',
+      };
+    },
+  },
+  {
+    loading: false,
+    data: null,
+    error: null,
+    test: 'test',
+  }
+);
+
+export default UserReducer;

--- a/src/fixtures/success/.flowconfig
+++ b/src/fixtures/success/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+
+[include]
+../../index.js
+
+[libs]
+../../../flow-typed
+
+[lints]
+
+[options]
+
+[strict]

--- a/src/fixtures/success/flow-success.js
+++ b/src/fixtures/success/flow-success.js
@@ -1,0 +1,58 @@
+// @flow
+import type {Reducer} from 'redux';
+import {createRPCReducer} from '../../index.js';
+
+type UserDataType = {
+  firstName: string,
+  lastName: string,
+};
+type ErrorType = {
+  message: string,
+};
+
+export type UserStateType = {|
+  loading: boolean,
+  data: ?UserDataType,
+  error: ?ErrorType,
+|};
+
+export type UserActionType = {|
+  type: string,
+  payload: {
+    data: ?UserDataType,
+    error: ?ErrorType,
+  },
+|};
+
+const UserReducer: Reducer<UserStateType, UserActionType> = createRPCReducer(
+  'getUser',
+  {
+    start: state => {
+      return {
+        ...state,
+        loading: true,
+      };
+    },
+    success: (state, action) => {
+      return {
+        ...state,
+        loading: false,
+        data: action.payload.data,
+      };
+    },
+    failure: (state, action) => {
+      return {
+        loading: false,
+        data: null,
+        error: action.payload.error,
+      };
+    },
+  },
+  {
+    loading: false,
+    data: null,
+    error: null,
+  }
+);
+
+export default UserReducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,7 +1575,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.5:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -2090,6 +2090,18 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This fixes issues with the `createRPCReducer` interface when working with flow types by using generics rather than the existential operator `*` whenever possible. This allows you to create a flow typed rpc reducer using the `Reducer` type helper from redux. For example:

```js
import type {Reducer} from 'redux';
import {createRPCReducer} from 'fusion-rpc-redux';

const StateType = {|
  a: string,
  b: boolean
|};

const ActionType = {|
  type: string,
  payload: {
    a: string,
    b : boolean
  }
|}

const reducer: Reducer<StateType, ActionType> = createRPCReducer('rpcId', {
  // ...
});
```