### PR TITLE
Default startValue to empty object again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ function getNormalizedReducers<S, A: ActionType>(
 export function createRPCReducer<S, A: ActionType>(
   rpcId: string,
   reducers: RPCReducersType<S, A>,
-  startValue: S
+  startValue: any = {}
 ): Reducer<S, A> {
   const actionNames = createActionNames(rpcId);
   const normalizedReducers = getNormalizedReducers(reducers);


### PR DESCRIPTION
This was inadvertently removed in https://github.com/fusionjs/fusion-rpc-redux/pull/108/files#diff-1fdf421c05c1140f6d71444ea2b27638L64