### PR TITLE
Allow mapStateToProps to amend existing rpc arguments

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -54,7 +54,8 @@ test('createRPCHandler success', t => {
   const handler = createRPCHandler({
     actions: {
       start: args => {
-        t.equal(args, 'transformed-args');
+        t.equal(args.transformed, 'transformed-args');
+        t.equal(args.mapped, 'mapped-params');
         return 'start';
       },
       success: result => {
@@ -83,13 +84,20 @@ test('createRPCHandler success', t => {
       },
     },
     rpcId: 'test',
-    mapStateToParams: state => {
+    mapStateToParams: (state, args) => {
+      t.equal(args, 'args');
       t.equal(state, 'test-state');
-      return 'mapped-params';
+      return {
+        args: args,
+        mapped: 'mapped-params',
+      };
     },
     transformParams: params => {
-      t.equal(params, 'mapped-params');
-      return 'transformed-args';
+      t.equal(params.mapped, 'mapped-params');
+      return {
+        mapped: params.mapped,
+        transformed: 'transformed-args',
+      };
     },
   });
   const result = handler('args');

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export function createRPCHandler({
   }
   return (args: any) => {
     if (mapStateToParams) {
-      args = mapStateToParams(store.getState());
+      args = mapStateToParams(store.getState(), args);
     }
     if (transformParams) {
       args = transformParams(args);


### PR DESCRIPTION
This allows for mapToState to amend incoming request params, not simply overwrite. A case where this is helpful is to populate values stored in redux that are common to multiple or all requests.

This resolves #126