### PR TITLE
Release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "fusion-rpc-redux",
   "description": "Triggers Redux actions when RPC methods are called",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": "fusionjs/fusion-rpc-redux",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "browser": {
@@ -49,8 +52,7 @@
     "lint": "eslint . --ignore-path .gitignore",
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-tests && cup build-tests",
-    "just-test":
-      "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
+    "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "prepublish": "npm run transpile"
   },


### PR DESCRIPTION
- Allow mapStateToProps to amend existing rpc arguments ([#129](https://github.com/fusionjs/fusion-rpc-redux/pull/129))