### PR TITLE
Add initalArgs to error payload

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -123,6 +123,7 @@ test('createRPCHandler failure', t => {
       },
       failure: e => {
         t.equals(e.message, error.message);
+        t.deepEqual(e.initialArgs, 'transformed-args');
         return 'failure';
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,7 @@ export function createRPCHandler({
           return obj;
         }, {});
         delete error.stack;
+        error.initialArgs = args;
         store.dispatch(actions && actions.failure(error));
         return e;
       });


### PR DESCRIPTION
Sometimes to properly handle an error you need access to the initial
request context. This PR adds initialArgs to the error payload.

An example of when this is necessary is a single reducer that stores the
results of multiple API requests under different keys. For example:

```
a: APICall ResponseA
b: APICall ResponseB
c: APICall ResponseC
```

Under the current framework, if we handle an error in our reducer, we
don't know whether the error is tied to a, b, or c. One way to solve
this is to have a handler on the server try/catch and return an
identifier (e.g. A), but this is not always possible. If a timeout or
network error occurred, the handler on the server might not even be
invoked and therefore wouldn't have the opportunity to provide an
indentifier to the request.

Another way of handling this would be for us to write our own
thunk-style handler for RPCs, but this seems against the spirit of
Fusion.

By exposing initialArgs, we can do:

```js
{
  start: (state, action) => ({
    ...state,
    [action.payload.requestId]: {error: false},
  }),
  failure: (state, action) => ({
    [action.payload.initialArgs.requestId]: {error: true},
  }),
}
```

Incidentally, this partially fixes https://github.com/fusionjs/fusion-rpc-redux/issues/136.