### PR TITLE
Do not restore the promise chain on error, instead continue errors

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -277,7 +277,7 @@ test('createRPCHandler failure', t => {
   });
   const result = handler('args');
   t.ok(result instanceof Promise);
-  result.then(reject => {
+  result.catch(reject => {
     t.equal(reject, error);
     t.end();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ export function createRPCHandler({
         delete error.stack;
         error.initialArgs = args;
         store.dispatch(actions && actions.failure(error));
-        return e;
+        throw e;
       });
   };
 }


### PR DESCRIPTION
Hello,

I have an issue where I'm using the promise in one of my components and it is not able to `catch` the error because returning the error restores the promise chain to be handled by the next `then`. 

For example inside the component: 

```
  update = (data) => {
    this.props
      .updateData(data)
      .then(data => this.onSuccess(data))
      .catch(err => this.onError(err));
  };
```

The above code will never run `this.onError(err)` even if in the error case.