### PR TITLE
Release v1.4.0-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-rpc-redux",
   "description": "Triggers Redux actions when RPC methods are called",
-  "version": "1.4.0-0",
+  "version": "1.4.0-1",
   "license": "MIT",
   "repository": "fusionjs/fusion-rpc-redux",
   "files": [


### PR DESCRIPTION
- Do not restore the promise chain on error, instead continue errors ([#154](https://github.com/fusionjs/fusion-rpc-redux/pull/154))
- Export type ActionType to be reused ([#152](https://github.com/fusionjs/fusion-rpc-redux/pull/152))