### PR TITLE
Revert #154

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -277,7 +277,7 @@ test('createRPCHandler failure', t => {
   });
   const result = handler('args');
   t.ok(result instanceof Promise);
-  result.catch(reject => {
+  result.then(reject => {
     t.equal(reject, error);
     t.end();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ export function createRPCHandler({
         delete error.stack;
         error.initialArgs = args;
         store.dispatch(actions && actions.failure(error));
-        throw e;
+        return e;
       });
   };
 }


### PR DESCRIPTION
Revert "Do not restore the promise chain on error, instead continue errors (#154)"

This reverts commit d522c10652aa6c57538266720ac46317b3248c5a.

The commit introduced a breaking change, so is being reverted to mitigate issues. Further conversation is taking place to come up with a more long-term fix